### PR TITLE
fix unexpected return's nest

### DIFF
--- a/lib/senju_kan_non.rb
+++ b/lib/senju_kan_non.rb
@@ -8,15 +8,14 @@ module SenjuKanNon
 
       keys = issai.keys
       idx = 0
-      records = []
 
       issai.each_value do |shujo|
         return false unless shujo.kind_of?(Array)
         neighbor = issai[keys[idx + 1]]
-        return records unless neighbor
+        return nil unless neighbor
 
-        records << combine(shujo, neighbor)
-        idx += 1
+        # TODO: need fix for issai has 3 or more params
+        return combine(shujo, neighbor)
       end
     end
 
@@ -26,7 +25,7 @@ module SenjuKanNon
         return nil unless values.kind_of?(Array)
         combinations = []
         base.each do |item|
-          values.map do |value|
+          values.each do |value|
             combinations << [item,value]
           end
         end

--- a/spec/senju_kan_non_spec.rb
+++ b/spec/senju_kan_non_spec.rb
@@ -30,7 +30,7 @@ RSpec.describe SenjuKanNon do
       end
 
       it "return pairwised Array" do
-        expect(subject.flatten.count).to eq(18)
+        expect(subject.count).to eq(9)
       end
     end
   end


### PR DESCRIPTION
expected
```
SenjuKanNon.redeem(first_group: [1,2,3], second_group: [9,8,7])
```
returns
```
 [[1, 9], [1, 8], [1, 7], [2, 9], [2, 8], [2, 7], [3, 9], [3, 8], [3, 7]]
```

but, actually returned
```
[[[1, 9], [1, 8], [1, 7], [2, 9], [2, 8], [2, 7], [3, 9], [3, 8], [3, 7]]]
```
