### PR TITLE
unable to transpose

### DIFF
--- a/lib/senju_kan_non.rb
+++ b/lib/senju_kan_non.rb
@@ -24,6 +24,7 @@ module SenjuKanNon
           gasshou(first_eye, first_hand, second_eye, second_hand)
         end
 
+        fill_short_values(issai_shujo)
         parse_columns_to_row
       end
 
@@ -36,8 +37,23 @@ module SenjuKanNon
         end
       end
 
-      def parse_columns_to_row
-        @riyaku.values.transpose
+      def fill_short_values(issai_shujo)
+        filling_size = @riyaku.values.map(&:size).max
+        @riyaku.each do |eye, hand|
+          if hand.size < filling_size
+            (1..(filling_size - hand.size)).each do |num|
+              if issai_shujo[eye][num].nil?
+                @riyaku[eye] << issai_shujo[eye][0]
+              else
+                @riyaku[eye] << issai_shujo[eye][num]
+              end
+            end
+          end
+        end
       end
-  end
+
+      def parse_columns_to_row
+        @riyaku.values.transpose.uniq
+      end
+    end
 end

--- a/lib/senju_kan_non/version.rb
+++ b/lib/senju_kan_non/version.rb
@@ -1,3 +1,3 @@
 module SenjuKanNon
-  VERSION = "0.1.1"
+  VERSION = "0.1.2"
 end

--- a/spec/senju_kan_non_spec.rb
+++ b/spec/senju_kan_non_spec.rb
@@ -44,7 +44,7 @@ RSpec.describe SenjuKanNon do
       end
 
       it "return pairwised Array" do
-        expect(subject.count).to eq(18)
+        expect(subject.count).to eq(15)
       end
     end
 
@@ -58,7 +58,39 @@ RSpec.describe SenjuKanNon do
       end
 
       it "return pairwised Array" do
-        expect(subject.count).to eq(27)
+        expect(subject.count).to eq(21)
+      end
+    end
+
+    context "valid different size params" do
+      let(:issai) do
+        { first: [1,2], second: ["a","b","c"] }
+      end
+
+      it "return Array" do
+        expect(subject.kind_of?(Array)).to eq(true)
+      end
+
+      it "return pairwised Array" do
+        expect(subject.count).to eq(6)
+      end
+    end
+
+    context "valid different params" do
+      let(:issai) do
+        { first: [1,2,3,4],
+          second: ["a"],
+          third: ["b"],
+          forth: ["c"]
+        }
+      end
+
+      it "return Array" do
+        expect(subject.kind_of?(Array)).to eq(true)
+      end
+
+      it "return pairwised Array" do
+        expect(subject.count).to eq(4)
       end
     end
   end


### PR DESCRIPTION
in some case like below, `'transpose': element size differs (6 should be 12) (IndexError)` occurred.
```
{ first: [1,2,3,4], second: ["a"], third: ["b"], forth: ["c"] }
```

to fix this problem, add `fill_short_values` method in order that every `@riyaku` param meets the largest param's size.